### PR TITLE
Fix text input colors for light and dark modes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
             </head>
             <body className={`${inter.className} min-h-screen leading-tight`}>
                 <Providers>
-                    <AppRoot appearance="dark" platform="base" id="tg-ui-root">
+                    <AppRoot platform="base" id="tg-ui-root">
                         {children}
                         <Toaster position="top-center" richColors />
                     </AppRoot>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -21,7 +21,7 @@
 --tg-viewport-stable-height: 100vh; */
 
 #tg-ui-root {
-    color: white;
+    color: var(--tg-theme-text-color);
     --tg-theme-button-color: #ff9900;
     --tg-theme-link-color: #f97316;
 }


### PR DESCRIPTION
## Summary
- Use Telegram theme text color variable for text fields to render correctly in light and dark modes
- Allow AppRoot to auto-detect appearance instead of forcing dark theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8c4cb7c9c832cb79124da0dae440e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Text color now adapts to the active theme, improving consistency across light and dark modes.
- Style
  - Replaced hard-coded text color with a theme variable for better theming support.
- Refactor
  - Removed forced dark appearance, allowing the app to respect the selected theme.
  - Simplified app root configuration without changing overall structure or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->