### PR TITLE
fix: handle `total_lkr` type consistency in calculations

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -317,7 +317,7 @@ export default function WalletPage() {
                                     </span>
                                     <span className="ml-3 rounded-md bg-blue-400/10 px-2 py-1 text-sm text-blue-400">
                                         ≈ රු.{" "}
-                                        {summary.total_lkr
+                                        {summary.total_lkr !== undefined && summary.total_lkr !== null
                                             ? formatLargeNumber(
                                                   Number(typeof summary.total_lkr === 'string' ? summary.total_lkr.replace(/,/g, "") : summary.total_lkr)
                                               )

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -319,7 +319,7 @@ export default function WalletPage() {
                                         ≈ රු.{" "}
                                         {summary.total_lkr
                                             ? formatLargeNumber(
-                                                  Number(summary.total_lkr.replace(/,/g, ""))
+                                                  Number(typeof summary.total_lkr === 'string' ? summary.total_lkr.replace(/,/g, "") : summary.total_lkr)
                                               )
                                             : "0"}
                                     </span>
@@ -471,7 +471,7 @@ export default function WalletPage() {
                                                     {formatLargeNumber(
                                                         (summary["24_hr_change"] *
                                                             Number(
-                                                                summary.total_lkr.replace(/,/g, "")
+                                                                typeof summary.total_lkr === 'string' ? summary.total_lkr.replace(/,/g, "") : (summary.total_lkr || 0)
                                                             )) /
                                                             100
                                                     )}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -317,9 +317,14 @@ export default function WalletPage() {
                                     </span>
                                     <span className="ml-3 rounded-md bg-blue-400/10 px-2 py-1 text-sm text-blue-400">
                                         ≈ රු.{" "}
-                                        {summary.total_lkr !== undefined && summary.total_lkr !== null
+                                        {summary.total_lkr !== undefined &&
+                                        summary.total_lkr !== null
                                             ? formatLargeNumber(
-                                                  Number(typeof summary.total_lkr === 'string' ? summary.total_lkr.replace(/,/g, "") : summary.total_lkr)
+                                                  Number(
+                                                      typeof summary.total_lkr === "string"
+                                                          ? summary.total_lkr.replace(/,/g, "")
+                                                          : summary.total_lkr
+                                                  )
                                               )
                                             : "0"}
                                     </span>
@@ -471,7 +476,13 @@ export default function WalletPage() {
                                                     {formatLargeNumber(
                                                         (summary["24_hr_change"] *
                                                             Number(
-                                                                typeof summary.total_lkr === 'string' ? summary.total_lkr.replace(/,/g, "") : (summary.total_lkr || 0)
+                                                                typeof summary.total_lkr ===
+                                                                    "string"
+                                                                    ? summary.total_lkr.replace(
+                                                                          /,/g,
+                                                                          ""
+                                                                      )
+                                                                    : summary.total_lkr || 0
                                                             )) /
                                                             100
                                                     )}


### PR DESCRIPTION
### **User description**
As per title..


___

### **PR Type**
Bug fix


___

### **Description**
- Add type guards for `total_lkr` to handle both string and number types

- Prevent runtime errors from inconsistent type handling in calculations

- Ensure safe number conversion with fallback values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["total_lkr value"] --> B{"Type check"}
  B -->|"string"| C["Remove commas and convert"]
  B -->|"number"| D["Use directly or fallback to 0"]
  C --> E["formatLargeNumber"]
  D --> E
  E --> F["Display LKR amount"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add type guards for total_lkr conversions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/dashboard/page.tsx

<ul><li>Added type guards to check if <code>summary.total_lkr</code> is a string before <br>calling <code>.replace()</code><br> <li> First location: Balance display section now handles both string and <br>number types<br> <li> Second location: 24-hour change calculation now safely converts <br><code>total_lkr</code> with fallback to 0<br> <li> Prevents potential runtime errors from type inconsistency</ul>


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/BitcoinDeepaBot-TMA/pull/59/files#diff-2c144079a4338bcfeecc2c0f8557d1a11faa7f2ba8ad92283138f05b8806888f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard now correctly handles financial values provided as text or numbers, avoiding formatting errors.
  * Balances show a reliable "0" fallback when data is missing and 24h P&L calculations work correctly for both string and numeric inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->